### PR TITLE
🚚(global) rename project into verna

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
 
 # Orchestrate our job run sequence
 workflows:
-  vernajs:
+  verna:
     jobs:
       # ---- Front-end jobs ----
       - build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,4 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unrealeased]
 
-[unreleased]: https://github.com/openfun/vernajs
+[unreleased]: https://github.com/openfun/verna

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-# Contributing to Verna.js
+# Contributing to Verna
 
-Want to contribute to Verna.js? We got you covered.
+Want to contribute to Verna? We got you covered.
 
 Take a look at our [contributing guide](https://richie.education/docs/contributing-guide) to get started.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Verna.js 🏗
-[![CircleCI](https://circleci.com/gh/openfun/vernajs/tree/main.svg?style=svg)](https://circleci.com/gh/openfun/vernajs/tree/main)
+# Verna 🏗
+[![CircleCI](https://circleci.com/gh/openfun/verna/tree/main.svg?style=svg)](https://circleci.com/gh/openfun/verna/tree/main)
 
 An extensible form builder based on [React JSON Schema Form](https://github.com/rjsf-team/react-jsonschema-form).
 
 ## Overview
 
-Verna.js is a React component to build forms that generates a [JSON Schema](http://json-schema.org/)
+Verna is a React component to build forms that generates a [JSON Schema](http://json-schema.org/)
 description of the form as output. The form can then be rendered with the [React JSON Schema Form](https://github.com/rjsf-team/react-jsonschema-form)
 library, which makes it fully extensible to fit your needs.
 
@@ -17,8 +17,8 @@ You can check examples available within the `examples` folder. Take a loot at th
 
 ### Instructions
 
-🚧 **`@openfun/vernajs` is not yet available on NPM. Stay tuned !**
-Soon instructions to install `@openfun/vernajs` within your project.
+🚧 **`@openfun/verna` is not yet available on NPM. Stay tuned !**
+Soon instructions to install `@openfun/verna` within your project.
 
 To run the project, you have to run :
 1. `yarn` or `npm install` 

--- a/examples/playground/README.md
+++ b/examples/playground/README.md
@@ -1,4 +1,4 @@
-# Verna.js - Playground
+# Verna - Playground
 
 You can use this playground for development purpose.
 

--- a/examples/playground/index.html
+++ b/examples/playground/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>🏗 Verna.js Playground</title>
+    <title>🏗 Verna Playground</title>
   </head>
   <body>
     <div id="root"></div>

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vernajs-playground",
+  "name": "verna-playground",
   "private": true,
   "version": "0.0.0",
   "scripts": {
@@ -8,7 +8,7 @@
   "dependencies": {
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "@openfun/vernajs": "../../src"
+    "@openfun/verna": "../../src"
   },
   "devDependencies": {
     "@types/react": "^17.0.33",

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -6,15 +6,15 @@
     "start": "vite"
   },
   "dependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "@openfun/verna": "../../src"
   },
   "devDependencies": {
-    "@types/react": "^17.0.33",
-    "@types/react-dom": "^17.0.10",
-    "@vitejs/plugin-react": "^1.0.7",
-    "typescript": "^4.5.4",
-    "vite": "^2.8.0"
+    "@types/react": "17.0.39",
+    "@types/react-dom": "17.0.11",
+    "@vitejs/plugin-react": "1.2.0",
+    "typescript": "4.5.5",
+    "vite": "2.8.4"
   }
 }

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,4 +1,4 @@
-import VernaForm from '@openfun/vernajs';
+import VernaForm from '@openfun/verna';
 
 function App() {
   return <VernaForm />;

--- a/examples/playground/vite.config.ts
+++ b/examples/playground/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@openfun/vernajs': resolve(__dirname, '../../src/'),
+      '@openfun/verna': resolve(__dirname, '../../src/'),
     },
   },
 });

--- a/examples/playground/yarn.lock
+++ b/examples/playground/yarn.lock
@@ -261,7 +261,7 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@openfun/vernajs@../../src":
+"@openfun/verna@../../src":
   version "0.0.0"
 
 "@rollup/pluginutils@^4.1.2":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@openfun/vernajs",
+  "name": "@openfun/verna",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@openfun/vernajs",
+      "name": "@openfun/verna",
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openfun/vernajs",
+  "name": "@openfun/verna",
   "version": "0.0.0",
   "private": false,
   "description": "An extensible form builder based on React JSON Schema Form.",
@@ -9,20 +9,20 @@
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "test": "jest"
   },
-  "main": "./dist/vernajs.umd.js",
+  "main": "./dist/verna.umd.js",
   "exports": {
     ".": {
-      "import": "./dist/vernajs.es.js",
-      "require": "./dist/vernajs.umd.js"
+      "import": "./dist/verna.es.js",
+      "require": "./dist/verna.umd.js"
     }
   },
-  "repository": "https://github.com/openfun/vernajs",
+  "repository": "https://github.com/openfun/verna",
   "author": {
     "name": "Open FUN (France Université Numérique)",
     "email": "fun.dev@fun-mooc.fr"
   },
   "bugs": {
-    "url": "https://github.com/openfun/vernajs/issues"
+    "url": "https://github.com/openfun/verna/issues"
   },
   "browserslist": [
     "last 2 versions",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
       name: 'index',
-      fileName: (format) => `vernajs.${format}.js`,
+      fileName: (format) => `verna.${format}.js`,
     },
     rollupOptions: {
       external: ['react'],


### PR DESCRIPTION
## Purpose

Remove the js mention in the project name to keep consistency between our
repository names.


## Proposal

- [x] Remove JS mention into the project name
