### PR TITLE
🚨(eslint) use string value instead of integer to declare rule status

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,9 +9,9 @@
   ],
   "plugins": ["@typescript-eslint","react","import","jsx-a11y"],
   "rules": {
-    "react/prop-types": 0,
+    "react/prop-types": "off",
     "indent": ["error", 2],
-    "linebreak-style": 1,
+    "linebreak-style": "warn",
     "react/react-in-jsx-scope": "off",
     "react/jsx-uses-react": "off"
   },


### PR DESCRIPTION
## Purpose

In order to improve consistency, we decided to use string "error", "warn" and
"off" to declare rule status instead of 2, 1, 0.


## Proposal

- [x] Update `.eslintrc` to use `error`, `warn` and `off` keywords instead of `2`, `1` and `0`
