### PR TITLE
:sparkles: (selector) Add a selector in the context to fetch and render only a part of the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Functionality to select and display only a section of the schema
 - Functionality to add or remove widgets and sections
 
 

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -8,7 +8,38 @@ function App() {
     title: 'A registration form',
     description: 'Desc registration form',
     type: 'object',
-    properties: {},
+    properties: {
+      testSection: {
+        type: 'object',
+        title: 'Sectiontest',
+        properties: {
+          field1: {
+            type: 'string',
+            title: 'Field name 1',
+            propertyNames: true,
+          },
+        },
+      },
+      secondSection: {
+        type: 'object',
+        title: 'Second section',
+        properties: {
+          secondField: {
+            type: 'string',
+            title: 'field second section',
+          },
+        },
+      },
+    },
+  };
+
+  const formData = {
+    secondSection: {
+      secondField: 'BBBBB',
+    },
+    testSection: {
+      field1: 'AAAAAAAA',
+    },
   };
 
   const widgets = {};
@@ -20,12 +51,13 @@ function App() {
   };
 
   return (
-    <div style={{ backgroundColor: 'lightcyan' }}>
+    <div style={{ backgroundColor: 'lightgray' }}>
       <VernaContextProvider
         defaultSchema={schemaDefault}
         defaultUiSchema={uiSchema}
+        defaultFormValues={formData}
         defaultReadOnly={false}
-        defaultWidget={widgets}
+        defaultWidgets={widgets}
       >
         <FormWrapper />
       </VernaContextProvider>

--- a/examples/playground/src/FormWrapper.tsx
+++ b/examples/playground/src/FormWrapper.tsx
@@ -1,14 +1,21 @@
 import VernaForm, { useVerna } from '@openfun/verna';
+import { JSONSchema7 } from 'json-schema';
 
 export default function FormWrapper() {
-  const { schema, uiSchema } = useVerna();
+  const { schema, uiSchema, setSelector } = useVerna();
 
   return (
     <>
-      <VernaForm onSubmit={() => console.log('Submit')} />
+      <VernaForm onSubmit={(formData) => console.log(formData)} />
       <button onClick={() => console.log('Schema:', { schema: schema, uiSchema: uiSchema })}>
         save form
       </button>
+      {Object.keys(schema.properties as JSONSchema7)?.map((key) => (
+        <button onClick={() => setSelector(key)} key={key}>
+          {key}
+        </button>
+      ))}
+      <button onClick={() => setSelector(undefined)}>default</button>
     </>
   );
 }

--- a/src/VernaContextProvider.tsx
+++ b/src/VernaContextProvider.tsx
@@ -1,40 +1,62 @@
-import * as React from 'react';
-import { PropsWithChildren, useState } from 'react';
+import { createContext, useContext, PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { JSONSchema7 } from 'json-schema';
 import type { UiSchema, Widget } from '@rjsf/core';
+import type { ISubmitEvent } from '@rjsf/core';
 
 function functionNotSet() {
   throw new Error('function context not set');
 }
 
-export interface WidgetType {
+export interface WidgetsType {
   [name: string]: Widget;
 }
 
 interface VernaContextProps {
+  fullSchema: JSONSchema7;
+  setFullSchema: (newSchema: JSONSchema7) => void;
+  fullUiSchema: UiSchema;
+  setFullUiSchema: (newUiSchema: UiSchema) => void;
   schema: JSONSchema7;
   setSchema: (newSchema: JSONSchema7) => void;
+  handleSubmit: <FormData = unknown>(
+    callback: (formData: unknown) => void,
+  ) => (event: ISubmitEvent<FormData>) => void;
+  selectedFormData: unknown;
   uiSchema: UiSchema;
   setUiSchema: (newUiSchema: UiSchema) => void;
-  widgets: WidgetType;
-  setWidgets: (newWidgets: WidgetType) => void;
+  formData: unknown;
+  setFormData: (newDefaultValues: unknown) => void;
+  widgets: WidgetsType;
+  setWidgets: (newWidgets: WidgetsType) => void;
   readOnly: boolean;
   setReadOnly: (newMode: boolean) => void;
+  selector: string | undefined;
+  setSelector: (selector: string | undefined) => void;
 }
 
-const VernaContext = React.createContext<VernaContextProps>({
+const VernaContext = createContext<VernaContextProps>({
+  fullSchema: {},
+  setFullSchema: () => functionNotSet(),
+  fullUiSchema: {},
+  setFullUiSchema: () => functionNotSet(),
   schema: {},
   setSchema: () => functionNotSet(),
   uiSchema: {},
   setUiSchema: () => functionNotSet(),
+  handleSubmit: () => () => functionNotSet(),
+  selectedFormData: {},
+  formData: {},
+  setFormData: () => functionNotSet(),
   widgets: {},
   setWidgets: () => functionNotSet(),
   readOnly: true,
   setReadOnly: () => functionNotSet(),
+  selector: undefined,
+  setSelector: () => functionNotSet(),
 });
 
 function useVerna() {
-  const context = React.useContext(VernaContext);
+  const context = useContext(VernaContext);
   if (!context) {
     throw new Error('UseVerna must be used within a VernaContextProvider');
   }
@@ -44,8 +66,10 @@ function useVerna() {
 interface VernaContextProviderProps {
   defaultSchema: JSONSchema7;
   defaultUiSchema: UiSchema;
-  defaultWidget: WidgetType;
+  defaultFormValues?: any;
+  defaultWidgets: WidgetsType;
   defaultReadOnly: boolean;
+  defaultSelector?: string;
 }
 
 function genDefaultUiSchema(schema: JSONSchema7, uiSchema: UiSchema) {
@@ -66,31 +90,126 @@ function genDefaultUiSchema(schema: JSONSchema7, uiSchema: UiSchema) {
   return defaultUi;
 }
 
+function getSelectedSchema(
+  defaultSchema: JSONSchema7,
+  defaultSelector: string | undefined,
+): JSONSchema7 {
+  if (defaultSelector && defaultSchema?.properties?.[defaultSelector]) {
+    return defaultSchema.properties[defaultSelector] as JSONSchema7;
+  }
+  return defaultSchema;
+}
+
+function getSelectedUiSchema(
+  defaultUiSchema: UiSchema,
+  defaultSelector: string | undefined,
+): UiSchema {
+  if (defaultSelector && defaultUiSchema?.[defaultSelector]) {
+    return defaultUiSchema[defaultSelector];
+  }
+  return defaultUiSchema;
+}
+
+function getDefaultValues(defaultValues: any, defaultSelector: string | undefined) {
+  if (defaultSelector && defaultValues) return defaultValues[defaultSelector];
+  return defaultValues;
+}
+
 function VernaContextProvider({
   defaultSchema,
   defaultUiSchema,
-  defaultWidget,
+  defaultFormValues,
+  defaultWidgets,
   defaultReadOnly,
+  defaultSelector,
   children,
 }: PropsWithChildren<VernaContextProviderProps>) {
-  const [schema, setSchema] = useState<JSONSchema7>(defaultSchema);
-  const [uiSchema, setUiSchema] = useState<UiSchema>(
+  // The full schemas are not used by the lib itself but may be used for further implementation
+  const [fullSchema, setFullSchema] = useState<JSONSchema7>(defaultSchema);
+  const [fullUiSchema, setFullUiSchema] = useState<UiSchema>(
     genDefaultUiSchema(defaultSchema, defaultUiSchema),
   );
+  const [schema, _setSchema] = useState<JSONSchema7>(
+    getSelectedSchema(defaultSchema, defaultSelector),
+  );
+  const [uiSchema, _setUiSchema] = useState<UiSchema>(
+    getSelectedUiSchema(defaultUiSchema, defaultSelector),
+  );
+  const [formData, setFormData] = useState(getDefaultValues(defaultFormValues, defaultSelector));
   const [readOnly, setReadOnly] = useState<boolean>(defaultReadOnly);
-  const [widgets, setWidgets] = useState<WidgetType>(defaultWidget);
+  const [widgets, setWidgets] = useState<WidgetsType>(defaultWidgets);
+  const [selector, setSelector] = useState<string | undefined>(defaultSelector);
+
+  // Schema and uiSchema target a part of fullSchema and fullUiSchema selected by the selector
+  function setSchema(newSchema: JSONSchema7) {
+    if (!selector) {
+      setFullSchema(newSchema);
+      return;
+    }
+    const newFullSchema = { ...fullSchema };
+    if (newFullSchema['properties']) {
+      newFullSchema.properties[selector] = newSchema;
+      _setSchema(newSchema);
+    }
+    setFullSchema(newFullSchema);
+  }
+
+  function setUiSchema(newUiSchema: UiSchema) {
+    if (!selector) {
+      setFullUiSchema(newUiSchema);
+      _setUiSchema(newUiSchema);
+      return;
+    }
+    const newFullUiSchema = { ...fullUiSchema };
+    newFullUiSchema[selector] = newUiSchema;
+    _setUiSchema(newUiSchema);
+    setFullUiSchema(newFullUiSchema);
+  }
+
+  useEffect(() => {
+    if (selector) {
+      if (fullSchema['properties']) setSchema(fullSchema['properties'][selector] as JSONSchema7);
+      if (fullUiSchema) setUiSchema(fullUiSchema[selector]);
+    } else {
+      _setSchema(fullSchema);
+      _setUiSchema(fullUiSchema);
+    }
+  }, [selector]);
+
+  const selectedFormData = useMemo(() => {
+    return selector && formData ? formData[selector] : formData;
+  }, [formData, selector]);
+
+  function handleSubmit<FormData = unknown>(callback?: (formData: unknown) => void) {
+    return (event: ISubmitEvent<FormData>) => {
+      const newFormData = { ...formData };
+      if (selector) newFormData[selector] = event.formData;
+      setFormData(newFormData);
+      callback && callback(newFormData);
+    };
+  }
 
   return (
     <VernaContext.Provider
       value={{
+        fullSchema,
+        setFullSchema,
+        fullUiSchema,
+        setFullUiSchema,
         schema,
         setSchema,
         uiSchema,
         setUiSchema,
+        handleSubmit,
+        selectedFormData,
+        formData,
+        setFormData,
         widgets,
         setWidgets,
         readOnly,
         setReadOnly,
+        selector,
+        setSelector,
       }}
     >
       {children}
@@ -101,7 +220,8 @@ function VernaContextProvider({
 VernaContextProvider.defaultProps = {
   defaultSchema: {},
   defaultUiSchema: {},
-  defaultWidget: {},
+  defaultWidgets: {},
+  defaultValues: {},
   defaultReadOnly: false,
 };
 

--- a/src/VernaForm.tsx
+++ b/src/VernaForm.tsx
@@ -1,26 +1,30 @@
 import { useVerna } from './VernaContextProvider';
 import Form from '@rjsf/core';
 import RenderFieldTemplate from './RenderMethods/RenderFieldTemplate';
-import { type FormProps } from '@rjsf/core';
 
 interface VernaFormProperties {
-  onSubmit?: FormProps<unknown>['onSubmit'];
+  onSubmit: (formData: unknown) => void;
 }
 
 function VernaForm({ onSubmit }: VernaFormProperties) {
-  const { schema, uiSchema, readOnly, widgets } = useVerna();
+  const { schema, uiSchema, readOnly, widgets, selectedFormData, handleSubmit } = useVerna();
 
   return (
     <Form
       className={'form'}
       schema={schema}
       uiSchema={uiSchema}
-      onSubmit={onSubmit}
+      formData={selectedFormData}
+      onSubmit={handleSubmit(onSubmit)}
       readonly={readOnly}
       widgets={widgets}
       FieldTemplate={RenderFieldTemplate}
     />
   );
 }
+
+VernaForm.defaultProps = {
+  onSubmit: () => undefined,
+};
 
 export default VernaForm;


### PR DESCRIPTION
## Purpose

Add a selector in the context to fetch and render only a part of the schema

## Proposal

Adding a selector state inside of the context of the lib.
You can access a setSelector function of the context to update it.
Once updated it will render only the sub schema.
The validation of the form will validate only the form displayed.
The save of the form will return the whole schema.
