### PR TITLE
🔧(renovate) update conf to include projects in examples directory

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,21 +2,13 @@
   "extends": [
     "github>openfun/renovate-configuration"
   ],
-  "packageRules": [
-    {
-      "enabled": false,
-      "groupName": "ignored js dependencies",
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "@testing-library/react",
-        "@types/react",
-        "@types/react-dom",
-        "react",
-        "react-dom",
-        "typescript"
-      ]
-    }
-  ]
+  "ignoreDeps": [
+    "@testing-library/react",
+    "@types/react",
+    "@types/react-dom",
+    "react",
+    "react-dom",
+    "typescript"
+  ],
+  "ignorePaths": ["**/node_modules/**"]
 }


### PR DESCRIPTION
## Purpose

By default, renovate is configured to ignore projects located into `examples` directory (1). So that's why playground dependencies was never updated. Furthermore, we can now use `ignoreDeps` property to tell renovate to not update some dependencies.

1 - This is not [mentioned in the doc](https://docs.renovatebot.com/configuration-options/#ignorepaths). But logs shows that ...
```
DEBUG: Found repo ignorePaths
{
  "ignorePaths": [
    "**/node_modules/**",
    "**/bower_components/**",
    "**/vendor/**",
    "**/examples/**",
    "**/__tests__/**",
    "**/test/**",
    "**/tests/**",
    "**/__fixtures__/**"
  ]
}
```

## Proposal

- [x] Do not use the default value of `ignorePaths` in order to include example projects
- [x] Use `ignoreDeps` to ignore some dependencies.
