### PR TITLE
Conf/improve dev experience

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "build:check": "if [ ! -d dist ] || [ $(find src -type f -newer dist) ] ; then yarn build ; fi",
-    "build:watch": "yarn build --watch",
+    "build:dev": "vite build --watch --logLevel warn --mode development",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "test": "jest"
   },

--- a/lib/package.json
+++ b/lib/package.json
@@ -5,7 +5,7 @@
   "description": "An extensible form builder based on React JSON Schema Form.",
   "scripts": {
     "build": "tsc && vite build",
-    "build:check": "if [ ! -d dist ] || [ $(find src -type f -newer dist) ] ; then yarn build ; fi",
+    "build:check": "if [ ! -d dist ] || [ -n \"$(find src -type f -newer dist)\" ] ; then yarn build ; fi",
     "build:dev": "vite build --watch --logLevel warn --mode development",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
     "test": "jest"

--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -4,14 +4,15 @@ import react from '@vitejs/plugin-react';
 import typescript from '@rollup/plugin-typescript';
 
 // https://vitejs.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   build: {
     lib: {
       entry: resolve(__dirname, './src/index.ts'),
-      fileName: (format) => (format === 'es' ? 'index.js' : `index.${format}.js`),
-      formats: ['es', 'umd'],
+      fileName: () => 'index.js',
+      formats: ['es'],
       name: 'index',
     },
+    minify: mode !== 'development',
     rollupOptions: {
       external: ['react', 'react-dom', 'react-intl'],
       output: {
@@ -32,7 +33,7 @@ export default defineConfig({
             resolve(__dirname, './src/tests'),
             resolve(__dirname, './src/**/*.spec.tsx?'),
           ],
-          noEmitOnError: true,
+          noEmitOnError: mode !== 'development',
           rootDir: resolve(__dirname, './src'),
           target: 'ESNext',
         }),
@@ -40,4 +41,4 @@ export default defineConfig({
     },
   },
   plugins: [react()],
-});
+}));

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "private": true,
   "scripts": {
     "build": "yarn workspace @openfun/verna build",
-    "dev:lib": "yarn workspace @openfun/verna build:watch",
+    "dev:lib": "yarn workspace @openfun/verna build:dev",
     "dev:example": "yarn workspace ${VERNA_EXAMPLE:-verna-examples-playground} start",
     "dev": "concurrently -kc 'blue,magenta' 'yarn run dev:*'",
     "lint": "yarn workspaces run lint",


### PR DESCRIPTION
## Purpose

After a first usage of the monorepo, it seems the developer experience could be
improved. First we prevent dev processes to be killed as soon as there is a
typescript error within the lib. Furthermore, we update the log level from info
to warn to not pollute the console with useless information. Then in order to
speed up build process during development, we disable minify process. Finally,
we only build lib as es module since umd does not allow to break lib into chunks

Also the `build:check` did not work when several files have been modified.

## Proposal

- [x] Update command and vite conf to improve dev experience
- [x] Fix a bug with the `build:check` command
