### PR TITLE
Vite/enable aliases

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 **/node_modules
-dist
+**/dist

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@
       "jsx": true
     }
   },
+  "root": true,
   "env": {
     "browser": true,
     "es6": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,9 +7,15 @@
     "plugin:prettier/recommended",
     "plugin:react/recommended"
   ],
-  "plugins": ["@typescript-eslint","react","import","jsx-a11y"],
+  "plugins": ["@typescript-eslint","import","jsx-a11y","react"],
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
+    "import/order": ["error", {
+      "alphabetize": {
+        "order": "asc",
+        "caseInsensitive": true
+      }
+    }],
     "linebreak-style": "warn",
     "no-duplicate-imports": "error",
     "no-console": ["error"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
   "rules": {
     "@typescript-eslint/no-unused-vars": "error",
     "linebreak-style": "warn",
+    "no-duplicate-imports": "error",
     "no-console": ["error"],
     "no-unused-vars": "off",
     "react/jsx-curly-brace-presence": ["error", { "props": "never", "children": "never" }],

--- a/examples/playground/.eslintrc
+++ b/examples/playground/.eslintrc
@@ -3,5 +3,10 @@
 {
   "rules": {
     "no-console": "off"
+  },
+  "settings": {
+    "import/resolver": {
+      "typescript": {}
+    }
   }
 }

--- a/examples/playground/package.json
+++ b/examples/playground/package.json
@@ -27,6 +27,7 @@
     "@vitejs/plugin-react": "2.0.0",
     "eslint": "8.20.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-import-resolver-typescript": "3.3.0",
     "eslint-plugin-compat": "4.0.2",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.0",

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -6,12 +6,12 @@ import FormWrapper from './FormWrapper';
 import TextWidget from './widgets/TextWidget';
 import PasswordWidget from './widgets/PasswordWidget';
 import QuizWidget from './widgets/QuizWidget';
-import './styles/verna.scss';
 import NumberWidget from './widgets/NumberWidget';
 import SelectWidget from './widgets/SelectWidget';
 import TextareaWidget from './widgets/TextareaWidget';
 import CheckboxWidget from './widgets/CheckboxWidget';
 import transformErrors from './ErrorCustom';
+import ':/styles/verna.scss';
 
 const messages = defineMessages({
   loading: {

--- a/examples/playground/src/App.tsx
+++ b/examples/playground/src/App.tsx
@@ -1,16 +1,16 @@
+import { VernaProvider, type VernaJSONSchemaType } from '@openfun/verna';
+import type { UiSchema } from '@rjsf/core';
 import { Suspense, useState } from 'react';
 import { FormattedMessage, useIntl, defineMessages } from 'react-intl';
-import type { UiSchema } from '@rjsf/core';
-import { VernaProvider, type VernaJSONSchemaType } from '@openfun/verna';
+import transformErrors from './ErrorCustom';
 import FormWrapper from './FormWrapper';
-import TextWidget from './widgets/TextWidget';
+import CheckboxWidget from './widgets/CheckboxWidget';
+import NumberWidget from './widgets/NumberWidget';
 import PasswordWidget from './widgets/PasswordWidget';
 import QuizWidget from './widgets/QuizWidget';
-import NumberWidget from './widgets/NumberWidget';
 import SelectWidget from './widgets/SelectWidget';
 import TextareaWidget from './widgets/TextareaWidget';
-import CheckboxWidget from './widgets/CheckboxWidget';
-import transformErrors from './ErrorCustom';
+import TextWidget from './widgets/TextWidget';
 import ':/styles/verna.scss';
 
 const messages = defineMessages({

--- a/examples/playground/src/FormWrapper.tsx
+++ b/examples/playground/src/FormWrapper.tsx
@@ -1,15 +1,15 @@
 import { useVerna, VernaForm, VernaToolbar } from '@openfun/verna';
 import { JSONSchema7 } from 'json-schema';
 import { defineMessages, FormattedMessage } from 'react-intl';
-import TextWidget from './widgetToolbarItems/TextWidget';
+import { useLocale } from './providers/LocaleProvider';
+import CheckboxesWidget from './widgetToolbarItems/CheckboxesWidget';
+import CheckboxWidget from './widgetToolbarItems/CheckboxWidget';
+import NumberWidget from './widgetToolbarItems/NumberWidget';
 import PasswordWidget from './widgetToolbarItems/PasswordWidget';
 import QuizWidget from './widgetToolbarItems/QuizWidget';
-import TextareaWidget from './widgetToolbarItems/TextareaWidget';
-import NumberWidget from './widgetToolbarItems/NumberWidget';
-import CheckboxWidget from './widgetToolbarItems/CheckboxWidget';
 import SelectWidget from './widgetToolbarItems/SelectWidget';
-import CheckboxesWidget from './widgetToolbarItems/CheckboxesWidget';
-import { useLocale } from './providers/LocaleProvider';
+import TextareaWidget from './widgetToolbarItems/TextareaWidget';
+import TextWidget from './widgetToolbarItems/TextWidget';
 
 interface FormWrapperProps {
   toggleEditorMode: () => void;

--- a/examples/playground/src/providers/TranslationProvider.tsx
+++ b/examples/playground/src/providers/TranslationProvider.tsx
@@ -1,8 +1,8 @@
 import { IntlProvider } from 'react-intl';
 import { PropsWithChildren } from 'react';
 import { useLocale } from './LocaleProvider';
-import en from '../translations/en-US.json';
-import fr from '../translations/fr-FR.json';
+import en from ':/translations/en-US.json';
+import fr from ':/translations/fr-FR.json';
 
 const resources = {
   'en-US': en,

--- a/examples/playground/src/providers/TranslationProvider.tsx
+++ b/examples/playground/src/providers/TranslationProvider.tsx
@@ -1,5 +1,5 @@
-import { IntlProvider } from 'react-intl';
 import { PropsWithChildren } from 'react';
+import { IntlProvider } from 'react-intl';
 import { useLocale } from './LocaleProvider';
 import en from ':/translations/en-US.json';
 import fr from ':/translations/fr-FR.json';

--- a/examples/playground/src/widgets/QuizWidget.tsx
+++ b/examples/playground/src/widgets/QuizWidget.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, useState } from 'react';
 import type { VernaWidgetProps } from '@openfun/verna/dist/types/Widgets';
+import { ChangeEvent, useState } from 'react';
 
 export default function QuizWidget(props: VernaWidgetProps) {
   const choices = ['a', 'b', 'c', 'd'] as const;

--- a/examples/playground/src/widgets/templates/TextTemplateWidget.tsx
+++ b/examples/playground/src/widgets/templates/TextTemplateWidget.tsx
@@ -1,5 +1,5 @@
-import Field, { FieldProps } from './Field';
 import { ChangeEventHandler, InputHTMLAttributes } from 'react';
+import Field, { FieldProps } from './Field';
 
 interface TextTemplateWidgetProps extends InputHTMLAttributes<unknown>, FieldProps {
   label: string;

--- a/examples/playground/tsconfig.json
+++ b/examples/playground/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../tsconfig.json",
   "include": ["src"],
+  "compilerOptions": {
+    // If you update aliases defined within "paths" property,
+    // you have also to update the "resolve.alias" property in ./vite.config.js
+    "paths": {
+      ":/*": ["./src/*"]
+    }
+  }
 }

--- a/examples/playground/vite.config.ts
+++ b/examples/playground/vite.config.ts
@@ -1,18 +1,16 @@
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  optimizeDeps: {
+    exclude: ['@openfun/verna'],
+  },
   plugins: [react()],
   resolve: {
-    alias: [
-      {
-        // We want to benefit of hmr when we are developing on @openfun/verna
-        // workspace. A little hack to achieve this it to use an alias to resolve
-        // the module through src instead of dist.
-        find: /^@openfun\/verna$/,
-        replacement: '@openfun/verna/src/index.ts',
-      },
-    ],
+    alias: {
+      ':': resolve(__dirname, './src'),
+    },
   },
 });

--- a/lib/.eslintrc
+++ b/lib/.eslintrc
@@ -1,0 +1,7 @@
+{
+  "settings": {
+    "import/resolver": {
+      "typescript": {}
+    }
+  }
+}

--- a/lib/jest.config.js
+++ b/lib/jest.config.js
@@ -2,6 +2,10 @@ module.exports = {
   coverageDirectory: '.coverage',
   moduleDirectories: ['<rootDir>/src', 'node_modules'],
   moduleFileExtensions: ['js', 'ts', 'tsx'],
+  moduleNameMapper: {
+    // Map aliases defined in tsconfig.json to the absolute path of the module
+    '^:/(.*)$': '<rootDir>/src/$1',
+  },
   resolver: '<rootDir>/jest/resolver.js',
   setupFilesAfterEnv: ['<rootDir>/jest/setup.js'],
   testEnvironment: 'jsdom',

--- a/lib/package.json
+++ b/lib/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc && vite build",
     "build:check": "if [ ! -d dist ] || [ -n \"$(find src -type f -newer dist)\" ] ; then yarn build ; fi",
-    "build:dev": "vite build --watch --logLevel warn --mode development",
+    "build:dev": "vite build --watch --logLevel warn --mode development --config ./vite.dev.config.ts",
     "i18n:extract": "yarn formatjs extract --id-interpolation-pattern '[sha512:contenthash:base64:6]' --format crowdin './src/**/*.ts*' --ignore './src/**/*.spec.ts*' --out-file './i18n/frontend.json'",
     "i18n:compile": "yarn formatjs compile-folder --format crowdin ./i18n/locales ./src/translations",
     "lint": "eslint 'src/**/*.{ts,tsx}'",

--- a/lib/package.json
+++ b/lib/package.json
@@ -71,6 +71,7 @@
     "@vitejs/plugin-react": "2.0.0",
     "eslint": "8.20.0",
     "eslint-config-prettier": "8.5.0",
+    "eslint-import-resolver-typescript": "3.3.0",
     "eslint-plugin-compat": "4.0.2",
     "eslint-plugin-import": "2.26.0",
     "eslint-plugin-jsx-a11y": "6.6.0",

--- a/lib/src/components/EditorFieldTemplate/DropZone.tsx
+++ b/lib/src/components/EditorFieldTemplate/DropZone.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
+import { useVerna } from ':/providers/VernaProvider';
 import ShowCaseWidgetProps from ':/types/Widgets';
 import { addWidget } from ':/utils/schema';
-import { useVerna } from ':/providers/VernaProvider';
 
 export interface DropZoneProps {
   id: string;

--- a/lib/src/components/EditorFieldTemplate/DropZone.tsx
+++ b/lib/src/components/EditorFieldTemplate/DropZone.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import ShowCaseWidgetProps from '../../types/Widgets';
-import { addWidget } from '../../utils/schema';
-import { useVerna } from '../../providers/VernaProvider';
+import ShowCaseWidgetProps from ':/types/Widgets';
+import { addWidget } from ':/utils/schema';
+import { useVerna } from ':/providers/VernaProvider';
 
 export interface DropZoneProps {
   id: string;

--- a/lib/src/components/EditorFieldTemplate/index.tsx
+++ b/lib/src/components/EditorFieldTemplate/index.tsx
@@ -5,9 +5,8 @@ import { v4 as uuidv4 } from 'uuid';
 import ShowCaseWidgetProps from ':/types/Widgets';
 import { RJSF_ID_SEPARATOR } from ':/settings';
 import { useVerna } from ':/providers/VernaProvider';
-import { addWidget, addSection } from ':/utils/schema';
+import { addWidget, addSection, removeSection, removeWidget } from ':/utils/schema';
 import WidgetPropertiesForm from ':/components/PropertiesForms/WidgetPropertiesForm';
-import { removeSection, removeWidget } from ':/utils/schema';
 
 const messages = defineMessages({
   addInput: {

--- a/lib/src/components/EditorFieldTemplate/index.tsx
+++ b/lib/src/components/EditorFieldTemplate/index.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
 import type { FieldTemplateProps } from '@rjsf/core';
+import React, { useState } from 'react';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
-import ShowCaseWidgetProps from ':/types/Widgets';
-import { RJSF_ID_SEPARATOR } from ':/settings';
-import { useVerna } from ':/providers/VernaProvider';
-import { addWidget, addSection, removeSection, removeWidget } from ':/utils/schema';
 import WidgetPropertiesForm from ':/components/PropertiesForms/WidgetPropertiesForm';
+import { useVerna } from ':/providers/VernaProvider';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import ShowCaseWidgetProps from ':/types/Widgets';
+import { addWidget, addSection, removeSection, removeWidget } from ':/utils/schema';
 
 const messages = defineMessages({
   addInput: {

--- a/lib/src/components/EditorFieldTemplate/index.tsx
+++ b/lib/src/components/EditorFieldTemplate/index.tsx
@@ -2,12 +2,12 @@ import React, { useState } from 'react';
 import type { FieldTemplateProps } from '@rjsf/core';
 import { defineMessages, FormattedMessage } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
-import ShowCaseWidgetProps from '../../types/Widgets';
-import { RJSF_ID_SEPARATOR } from '../../settings';
-import { useVerna } from '../../providers/VernaProvider';
-import { addWidget, addSection } from '../../utils/schema';
-import WidgetPropertiesForm from '../PropertiesForms/WidgetPropertiesForm';
-import { removeSection, removeWidget } from '../../utils/schema';
+import ShowCaseWidgetProps from ':/types/Widgets';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import { useVerna } from ':/providers/VernaProvider';
+import { addWidget, addSection } from ':/utils/schema';
+import WidgetPropertiesForm from ':/components/PropertiesForms/WidgetPropertiesForm';
+import { removeSection, removeWidget } from ':/utils/schema';
 
 const messages = defineMessages({
   addInput: {

--- a/lib/src/components/Fields/Section.tsx
+++ b/lib/src/components/Fields/Section.tsx
@@ -1,8 +1,8 @@
-import { defineMessages, FormattedMessage } from 'react-intl';
 import type { ObjectFieldTemplateProps } from '@rjsf/core';
 import React, { useState } from 'react';
-import { useVerna } from ':/providers/VernaProvider';
+import { defineMessages, FormattedMessage } from 'react-intl';
 import SectionPropertiesForm from ':/components/PropertiesForms/SectionPropertiesForm';
+import { useVerna } from ':/providers/VernaProvider';
 
 const messages = defineMessages({
   parameters: {

--- a/lib/src/components/Fields/Section.tsx
+++ b/lib/src/components/Fields/Section.tsx
@@ -1,8 +1,8 @@
 import { defineMessages, FormattedMessage } from 'react-intl';
 import type { ObjectFieldTemplateProps } from '@rjsf/core';
 import React, { useState } from 'react';
-import { useVerna } from '../../providers/VernaProvider';
-import SectionPropertiesForm from '../PropertiesForms/SectionPropertiesForm';
+import { useVerna } from ':/providers/VernaProvider';
+import SectionPropertiesForm from ':/components/PropertiesForms/SectionPropertiesForm';
 
 const messages = defineMessages({
   parameters: {

--- a/lib/src/components/PropertiesForms/SectionPropertiesForm.tsx
+++ b/lib/src/components/PropertiesForms/SectionPropertiesForm.tsx
@@ -1,14 +1,11 @@
 import Form, { type ISubmitEvent, type UiSchema } from '@rjsf/core';
 import { defineMessages, useIntl } from 'react-intl';
 import { FormEvent, useMemo } from 'react';
-import { useVerna } from '../../providers/VernaProvider';
-import { RJSF_ID_SEPARATOR } from '../../settings';
-import { DEFAULT_PROPERTY_TRANSLATION } from '../../utils/translation';
-import { sectionParametersSchema } from '../../templates';
-import {
-  SectionParameters,
-  updateSectionProperties,
-} from '../../utils/schema/updateSectionProperties';
+import { useVerna } from ':/providers/VernaProvider';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import { DEFAULT_PROPERTY_TRANSLATION } from ':/utils/translation';
+import { sectionParametersSchema } from ':/templates';
+import { SectionParameters, updateSectionProperties } from ':/utils/schema/updateSectionProperties';
 
 interface SectionPropertiesFormProps {
   onClose: () => void;

--- a/lib/src/components/PropertiesForms/SectionPropertiesForm.tsx
+++ b/lib/src/components/PropertiesForms/SectionPropertiesForm.tsx
@@ -1,11 +1,11 @@
 import Form, { type ISubmitEvent, type UiSchema } from '@rjsf/core';
-import { defineMessages, useIntl } from 'react-intl';
 import { FormEvent, useMemo } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import { useVerna } from ':/providers/VernaProvider';
 import { RJSF_ID_SEPARATOR } from ':/settings';
-import { DEFAULT_PROPERTY_TRANSLATION } from ':/utils/translation';
 import { sectionParametersSchema } from ':/templates';
 import { SectionParameters, updateSectionProperties } from ':/utils/schema/updateSectionProperties';
+import { DEFAULT_PROPERTY_TRANSLATION } from ':/utils/translation';
 
 interface SectionPropertiesFormProps {
   onClose: () => void;

--- a/lib/src/components/PropertiesForms/WidgetPropertiesForm.tsx
+++ b/lib/src/components/PropertiesForms/WidgetPropertiesForm.tsx
@@ -1,15 +1,15 @@
 import Form, { type ISubmitEvent, type UiSchema } from '@rjsf/core';
-import { defineMessages, useIntl } from 'react-intl';
-import { FormEvent, useMemo } from 'react';
 import _ from 'lodash';
+import { FormEvent, useMemo } from 'react';
+import { defineMessages, useIntl } from 'react-intl';
 import { useVerna } from ':/providers/VernaProvider';
-import { getUiWidgetName } from ':/utils';
 import { RJSF_ID_SEPARATOR } from ':/settings';
+import { defaultWidgetProps } from ':/templates';
 import type VernaJSONSchemaType from ':/types/rjsf';
+import { Maybe } from ':/types/utils';
+import { getUiWidgetName } from ':/utils';
 import { Properties, updateWidgetProperties } from ':/utils/schema';
 import { DEFAULT_PROPERTY_TRANSLATION } from ':/utils/translation';
-import { Maybe } from ':/types/utils';
-import { defaultWidgetProps } from ':/templates';
 
 interface WidgetPropertiesFormProps {
   onClose: () => void;

--- a/lib/src/components/PropertiesForms/WidgetPropertiesForm.tsx
+++ b/lib/src/components/PropertiesForms/WidgetPropertiesForm.tsx
@@ -2,14 +2,14 @@ import Form, { type ISubmitEvent, type UiSchema } from '@rjsf/core';
 import { defineMessages, useIntl } from 'react-intl';
 import { FormEvent, useMemo } from 'react';
 import _ from 'lodash';
-import { useVerna } from '../../providers/VernaProvider';
-import { getUiWidgetName } from '../../utils/utils';
-import { RJSF_ID_SEPARATOR } from '../../settings';
-import type VernaJSONSchemaType from '../../types/rjsf';
-import { Properties, updateWidgetProperties } from '../../utils/schema';
-import { DEFAULT_PROPERTY_TRANSLATION } from '../../utils/translation';
-import { Maybe } from '../../types/utils';
-import { defaultWidgetProps } from '../../templates';
+import { useVerna } from ':/providers/VernaProvider';
+import { getUiWidgetName } from ':/utils';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import type VernaJSONSchemaType from ':/types/rjsf';
+import { Properties, updateWidgetProperties } from ':/utils/schema';
+import { DEFAULT_PROPERTY_TRANSLATION } from ':/utils/translation';
+import { Maybe } from ':/types/utils';
+import { defaultWidgetProps } from ':/templates';
 
 interface WidgetPropertiesFormProps {
   onClose: () => void;

--- a/lib/src/components/VernaForm/index.spec.tsx
+++ b/lib/src/components/VernaForm/index.spec.tsx
@@ -1,8 +1,9 @@
 import { type UiSchema } from '@rjsf/core';
 import { screen, render, waitFor } from '@testing-library/react';
-import { Suspense } from 'react';
-import _ from 'lodash';
 import userEvent from '@testing-library/user-event';
+import _ from 'lodash';
+import { Suspense } from 'react';
+import VernaForm from ':/components/VernaForm';
 import VernaProvider, { WidgetsType } from ':/providers/VernaProvider';
 import {
   schemaFactory,
@@ -10,7 +11,6 @@ import {
   uiSchemaFactory,
   widgetsFactory,
 } from ':/tests/mocks/factories';
-import VernaForm from ':/components/VernaForm';
 import { resolvePromisesOneByOne } from ':/tests/utils';
 
 describe('VernaForm', () => {

--- a/lib/src/components/VernaForm/index.spec.tsx
+++ b/lib/src/components/VernaForm/index.spec.tsx
@@ -3,15 +3,15 @@ import { screen, render, waitFor } from '@testing-library/react';
 import { Suspense } from 'react';
 import _ from 'lodash';
 import userEvent from '@testing-library/user-event';
-import VernaProvider, { WidgetsType } from '../../providers/VernaProvider';
+import VernaProvider, { WidgetsType } from ':/providers/VernaProvider';
 import {
   schemaFactory,
   translationsFactory,
   uiSchemaFactory,
   widgetsFactory,
-} from '../../tests/mocks/factories';
-import VernaForm from '../VernaForm';
-import { resolvePromisesOneByOne } from '../../tests/utils';
+} from ':/tests/mocks/factories';
+import VernaForm from ':/components/VernaForm';
+import { resolvePromisesOneByOne } from ':/tests/utils';
 
 describe('VernaForm', () => {
   async function clickOnLastAddInputButton() {

--- a/lib/src/components/VernaForm/index.tsx
+++ b/lib/src/components/VernaForm/index.tsx
@@ -1,9 +1,9 @@
 import Form from '@rjsf/core';
 import { useIntl } from 'react-intl';
 import { useMemo } from 'react';
-import { useVerna } from '../../providers/VernaProvider';
-import { RJSF_ID_SEPARATOR } from '../../settings';
-import { translateSchema } from '../../utils/translation';
+import { useVerna } from ':/providers/VernaProvider';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import { translateSchema } from ':/utils/translation';
 
 interface VernaFormProperties {
   onSubmit: (formData: unknown) => void;

--- a/lib/src/components/VernaForm/index.tsx
+++ b/lib/src/components/VernaForm/index.tsx
@@ -1,6 +1,6 @@
 import Form from '@rjsf/core';
-import { useIntl } from 'react-intl';
 import { useMemo } from 'react';
+import { useIntl } from 'react-intl';
 import { useVerna } from ':/providers/VernaProvider';
 import { RJSF_ID_SEPARATOR } from ':/settings';
 import { translateSchema } from ':/utils/translation';

--- a/lib/src/components/VernaToolbar/index.tsx
+++ b/lib/src/components/VernaToolbar/index.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import ShowCaseWidgetProps from '../../types/Widgets';
+import ShowCaseWidgetProps from ':/types/Widgets';
 
 interface VernaToolbarProps {
   children: ReactElement[];

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,7 +1,7 @@
-import VernaForm from ':/components/VernaForm';
-import VernaProvider, { useVerna } from ':/providers/VernaProvider';
-import VernaToolbar from ':/components/VernaToolbar';
 import Section from ':/components/Fields/Section';
+import VernaForm from ':/components/VernaForm';
+import VernaToolbar from ':/components/VernaToolbar';
+import VernaProvider, { useVerna } from ':/providers/VernaProvider';
 import type VernaJSONSchemaType from ':/types/rjsf';
 
 export { VernaForm, VernaProvider, useVerna, VernaToolbar, Section };

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -1,8 +1,8 @@
-import VernaForm from './components/VernaForm';
-import VernaProvider, { useVerna } from './providers/VernaProvider';
-import VernaToolbar from './components/VernaToolbar';
-import type VernaJSONSchemaType from './types/rjsf';
-import Section from './components/Fields/Section';
+import VernaForm from ':/components/VernaForm';
+import VernaProvider, { useVerna } from ':/providers/VernaProvider';
+import VernaToolbar from ':/components/VernaToolbar';
+import Section from ':/components/Fields/Section';
+import type VernaJSONSchemaType from ':/types/rjsf';
 
 export { VernaForm, VernaProvider, useVerna, VernaToolbar, Section };
 export type { VernaJSONSchemaType };

--- a/lib/src/providers/TranslationProvider/index.spec.tsx
+++ b/lib/src/providers/TranslationProvider/index.spec.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react';
 import { createIntl, FormattedMessage, type ResolvedIntlConfig } from 'react-intl';
 import TranslationProvider from '.';
 
-jest.mock('../../translations/fr-FR.json', () => ({
+jest.mock(':/translations/fr-FR.json', () => ({
   __esModule: true,
   default: {
     title: 'Un titre',

--- a/lib/src/providers/TranslationProvider/index.tsx
+++ b/lib/src/providers/TranslationProvider/index.tsx
@@ -1,8 +1,8 @@
 import { PropsWithChildren, useMemo } from 'react';
 import { createIntl, createIntlCache, RawIntlProvider, type ResolvedIntlConfig } from 'react-intl';
-import resourceLoader, { type ResourceLoader } from '../../utils/suspense/resourceLoader';
-import { VERNA_SUPPORTED_LOCALES } from '../../settings';
-import { TranslationType } from '../../types/translations';
+import resourceLoader, { type ResourceLoader } from ':/utils/suspense/resourceLoader';
+import { VERNA_SUPPORTED_LOCALES } from ':/settings';
+import { TranslationType } from ':/types/translations';
 
 interface TranslationProviderProps {
   defaultLocale?: string;
@@ -16,7 +16,7 @@ type MessageLoaders = Record<string, MessageLoader>;
 
 const messagesLoader = (locale: string): MessageLoader =>
   resourceLoader(() =>
-    import(`../../translations/${locale}.json`).then(
+    import(`:/translations/${locale}.json`).then(
       (response: { default: ResolvedIntlConfig['messages'] }) => response.default,
     ),
   );

--- a/lib/src/providers/TranslationProvider/index.tsx
+++ b/lib/src/providers/TranslationProvider/index.tsx
@@ -1,8 +1,8 @@
 import { PropsWithChildren, useMemo } from 'react';
 import { createIntl, createIntlCache, RawIntlProvider, type ResolvedIntlConfig } from 'react-intl';
-import resourceLoader, { type ResourceLoader } from ':/utils/suspense/resourceLoader';
 import { VERNA_SUPPORTED_LOCALES } from ':/settings';
 import { TranslationType } from ':/types/translations';
+import resourceLoader, { type ResourceLoader } from ':/utils/suspense/resourceLoader';
 
 interface TranslationProviderProps {
   defaultLocale?: string;

--- a/lib/src/providers/VernaProvider/index.spec.tsx
+++ b/lib/src/providers/VernaProvider/index.spec.tsx
@@ -5,8 +5,8 @@ import {
   translationsFactory,
   uiSchemaFactory,
   widgetsFactory,
-} from '../../tests/mocks/factories';
-import VernaForm from '../../components/VernaForm';
+} from ':/tests/mocks/factories';
+import VernaForm from ':/components/VernaForm';
 import VernaProvider, { type VernaProviderProps } from '.';
 
 describe('custom render components', () => {

--- a/lib/src/providers/VernaProvider/index.spec.tsx
+++ b/lib/src/providers/VernaProvider/index.spec.tsx
@@ -1,13 +1,13 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { Suspense } from 'react';
+import VernaProvider, { type VernaProviderProps } from '.';
+import VernaForm from ':/components/VernaForm';
 import {
   schemaFactory,
   translationsFactory,
   uiSchemaFactory,
   widgetsFactory,
 } from ':/tests/mocks/factories';
-import VernaForm from ':/components/VernaForm';
-import VernaProvider, { type VernaProviderProps } from '.';
 
 describe('custom render components', () => {
   const VernaSuspenseWrapper = (props: Partial<VernaProviderProps>) => (

--- a/lib/src/providers/VernaProvider/index.tsx
+++ b/lib/src/providers/VernaProvider/index.tsx
@@ -1,13 +1,3 @@
-import React, {
-  createContext,
-  FormEvent,
-  PropsWithChildren,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
-import { type ResolvedIntlConfig } from 'react-intl';
 import type {
   FieldTemplateProps,
   FormProps,
@@ -16,22 +6,32 @@ import type {
   UiSchema,
   Widget,
 } from '@rjsf/core';
+import React, {
+  FormEvent,
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { type ResolvedIntlConfig } from 'react-intl';
+import EditorFieldTemplate from ':/components/EditorFieldTemplate';
+import {
+  default as DefaultDropZone,
+  DropZoneProps,
+} from ':/components/EditorFieldTemplate/DropZone';
+import { default as DefaultSection } from ':/components/Fields/Section';
+import TranslationProvider from ':/providers/TranslationProvider';
 import { defaultVernaWidgets } from ':/templates';
 import VernaJSONSchemaType from ':/types/rjsf';
+import { TranslationType } from ':/types/translations';
 import {
   cleanUiSchema,
   getSelectedDefaultValues,
   getSelectedSchema,
   getSelectedUiSchema,
 } from ':/utils/schema';
-import { TranslationType } from ':/types/translations';
-import TranslationProvider from ':/providers/TranslationProvider';
-import { default as DefaultSection } from ':/components/Fields/Section';
-import EditorFieldTemplate from ':/components/EditorFieldTemplate';
-import {
-  default as DefaultDropZone,
-  DropZoneProps,
-} from ':/components/EditorFieldTemplate/DropZone';
 
 function functionNotSet() {
   throw new Error('function context not set');

--- a/lib/src/providers/VernaProvider/index.tsx
+++ b/lib/src/providers/VernaProvider/index.tsx
@@ -9,13 +9,13 @@ import React, {
 } from 'react';
 import { type ResolvedIntlConfig } from 'react-intl';
 import type {
-  ObjectFieldTemplateProps,
+  FieldTemplateProps,
+  FormProps,
   ISubmitEvent,
+  ObjectFieldTemplateProps,
   UiSchema,
   Widget,
-  FormProps,
 } from '@rjsf/core';
-import type { FieldTemplateProps } from '@rjsf/core';
 import { defaultVernaWidgets } from ':/templates';
 import VernaJSONSchemaType from ':/types/rjsf';
 import {

--- a/lib/src/providers/VernaProvider/index.tsx
+++ b/lib/src/providers/VernaProvider/index.tsx
@@ -16,22 +16,22 @@ import type {
   FormProps,
 } from '@rjsf/core';
 import type { FieldTemplateProps } from '@rjsf/core';
-import { defaultVernaWidgets } from '../../templates';
-import VernaJSONSchemaType from '../../types/rjsf';
+import { defaultVernaWidgets } from ':/templates';
+import VernaJSONSchemaType from ':/types/rjsf';
 import {
   cleanUiSchema,
   getSelectedDefaultValues,
   getSelectedSchema,
   getSelectedUiSchema,
-} from '../../utils/schema';
-import { TranslationType } from '../../types/translations';
-import TranslationProvider from '../TranslationProvider';
-import { default as DefaultSection } from '../../components/Fields/Section';
-import EditorFieldTemplate from '../../components/EditorFieldTemplate';
+} from ':/utils/schema';
+import { TranslationType } from ':/types/translations';
+import TranslationProvider from ':/providers/TranslationProvider';
+import { default as DefaultSection } from ':/components/Fields/Section';
+import EditorFieldTemplate from ':/components/EditorFieldTemplate';
 import {
   default as DefaultDropZone,
   DropZoneProps,
-} from '../../components/EditorFieldTemplate/DropZone';
+} from ':/components/EditorFieldTemplate/DropZone';
 
 function functionNotSet() {
   throw new Error('function context not set');

--- a/lib/src/templates.ts
+++ b/lib/src/templates.ts
@@ -1,5 +1,5 @@
 import { JSONSchema7TypeName } from 'json-schema';
-import VernaJSONSchemaType from './types/rjsf';
+import VernaJSONSchemaType from ':/types/rjsf';
 
 const stringDefinition = (type: JSONSchema7TypeName = 'string'): VernaJSONSchemaType => {
   const def: VernaJSONSchemaType = {

--- a/lib/src/tests/Sections.spec.tsx
+++ b/lib/src/tests/Sections.spec.tsx
@@ -1,16 +1,16 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
-import VernaProvider from '../providers/VernaProvider';
+import VernaProvider from ':/providers/VernaProvider';
 import {
   selectSchemaFactory,
   translationsFactory,
   selectUiSchemaFactory,
   confSchemaFactory,
   widgetsFactory,
-} from './mocks/factories';
-import VernaForm from '../components/VernaForm';
-import VernaJSONSchemaType from '../types/rjsf';
+} from ':/tests/mocks/factories';
+import VernaForm from ':/components/VernaForm';
+import VernaJSONSchemaType from ':/types/rjsf';
 
 describe('section properties edition', () => {
   const VernaSuspenseWrapper = ({ configSchema }: { configSchema?: VernaJSONSchemaType }) => {

--- a/lib/src/tests/Sections.spec.tsx
+++ b/lib/src/tests/Sections.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
+import VernaForm from ':/components/VernaForm';
 import VernaProvider from ':/providers/VernaProvider';
 import {
   selectSchemaFactory,
@@ -9,7 +10,6 @@ import {
   confSchemaFactory,
   widgetsFactory,
 } from ':/tests/mocks/factories';
-import VernaForm from ':/components/VernaForm';
 import VernaJSONSchemaType from ':/types/rjsf';
 
 describe('section properties edition', () => {

--- a/lib/src/tests/Widgets.spec.tsx
+++ b/lib/src/tests/Widgets.spec.tsx
@@ -1,16 +1,16 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
-import VernaProvider from '../providers/VernaProvider';
+import VernaProvider from ':/providers/VernaProvider';
 import {
   selectSchemaFactory,
   translationsFactory,
   selectUiSchemaFactory,
   confSchemaFactory,
   widgetsFactory,
-} from './mocks/factories';
-import VernaForm from '../components/VernaForm';
-import VernaJSONSchemaType from '../types/rjsf';
+} from ':/tests/mocks/factories';
+import VernaForm from ':/components/VernaForm';
+import VernaJSONSchemaType from ':/types/rjsf';
 
 describe('widget properties edition', () => {
   const VernaSuspenseWrapper = ({ configSchema }: { configSchema?: VernaJSONSchemaType }) => {

--- a/lib/src/tests/Widgets.spec.tsx
+++ b/lib/src/tests/Widgets.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
+import VernaForm from ':/components/VernaForm';
 import VernaProvider from ':/providers/VernaProvider';
 import {
   selectSchemaFactory,
@@ -9,7 +10,6 @@ import {
   confSchemaFactory,
   widgetsFactory,
 } from ':/tests/mocks/factories';
-import VernaForm from ':/components/VernaForm';
 import VernaJSONSchemaType from ':/types/rjsf';
 
 describe('widget properties edition', () => {

--- a/lib/src/tests/errors.spec.tsx
+++ b/lib/src/tests/errors.spec.tsx
@@ -6,10 +6,10 @@ import {
   translationsFactory,
   uiSchemaFactory,
   widgetsFactory,
-} from './mocks/factories';
+} from ':/tests/mocks/factories';
 import { render, screen, waitFor } from '@testing-library/react';
-import VernaProvider from '../providers/VernaProvider';
-import VernaForm from '../components/VernaForm';
+import VernaProvider from ':/providers/VernaProvider';
+import VernaForm from ':/components/VernaForm';
 
 describe('custom errors', () => {
   function transformErrors(errors: AjvError[]): AjvError[] {

--- a/lib/src/tests/errors.spec.tsx
+++ b/lib/src/tests/errors.spec.tsx
@@ -1,15 +1,15 @@
-import userEvent from '@testing-library/user-event';
 import type { AjvError } from '@rjsf/core';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Suspense } from 'react';
+import VernaForm from ':/components/VernaForm';
+import VernaProvider from ':/providers/VernaProvider';
 import {
   schemaFactory,
   translationsFactory,
   uiSchemaFactory,
   widgetsFactory,
 } from ':/tests/mocks/factories';
-import { render, screen, waitFor } from '@testing-library/react';
-import VernaProvider from ':/providers/VernaProvider';
-import VernaForm from ':/components/VernaForm';
 
 describe('custom errors', () => {
   function transformErrors(errors: AjvError[]): AjvError[] {

--- a/lib/src/tests/mocks/NumberWidget.tsx
+++ b/lib/src/tests/mocks/NumberWidget.tsx
@@ -1,5 +1,5 @@
 import { TextTemplateWidget } from './templates/TextTemplateWidget';
-import { VernaWidgetProps } from '../../types/Widgets';
+import { VernaWidgetProps } from ':/types/Widgets';
 
 export default function TextWidget(props: VernaWidgetProps) {
   return (

--- a/lib/src/tests/mocks/factories.ts
+++ b/lib/src/tests/mocks/factories.ts
@@ -1,9 +1,9 @@
 import type { UiSchema } from '@rjsf/core';
 import { merge } from 'lodash';
-import VernaJSONSchemaType from '../../types/rjsf';
+import VernaJSONSchemaType from ':/types/rjsf';
+import { TranslationType } from ':/types/translations';
 import SelectWidget from './SelectWidget';
 import NumberWidget from './NumberWidget';
-import { TranslationType } from '../../types/translations';
 
 const schemaFactory = (): VernaJSONSchemaType => ({
   description: 'root_description',

--- a/lib/src/tests/mocks/factories.ts
+++ b/lib/src/tests/mocks/factories.ts
@@ -1,9 +1,9 @@
 import type { UiSchema } from '@rjsf/core';
 import { merge } from 'lodash';
+import NumberWidget from './NumberWidget';
+import SelectWidget from './SelectWidget';
 import VernaJSONSchemaType from ':/types/rjsf';
 import { TranslationType } from ':/types/translations';
-import SelectWidget from './SelectWidget';
-import NumberWidget from './NumberWidget';
 
 const schemaFactory = (): VernaJSONSchemaType => ({
   description: 'root_description',

--- a/lib/src/tests/mocks/templates/TextTemplateWidget.tsx
+++ b/lib/src/tests/mocks/templates/TextTemplateWidget.tsx
@@ -1,5 +1,5 @@
-import Field, { FieldProps } from './Field';
 import { ChangeEventHandler, InputHTMLAttributes } from 'react';
+import Field, { FieldProps } from './Field';
 
 interface TextTemplateWidgetProps extends InputHTMLAttributes<unknown>, FieldProps {
   label: string;

--- a/lib/src/types/Widgets.ts
+++ b/lib/src/types/Widgets.ts
@@ -1,5 +1,5 @@
-import { JSONSchema7TypeName } from 'json-schema';
 import type { WidgetProps } from '@rjsf/core';
+import { JSONSchema7TypeName } from 'json-schema';
 import { ChangeEventHandler } from 'react';
 
 export default interface ShowCaseWidgetProps {

--- a/lib/src/utils/index.ts
+++ b/lib/src/utils/index.ts
@@ -1,6 +1,6 @@
 import type { UiSchema } from '@rjsf/core';
-import { RJSF_ID_SEPARATOR } from '../settings';
-import { Maybe } from '../types/utils';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import { Maybe } from ':/types/utils';
 
 /**
  * Retrieve the section name from the provided id.

--- a/lib/src/utils/schema/adders.ts
+++ b/lib/src/utils/schema/adders.ts
@@ -1,10 +1,10 @@
-import { v4 as uuidv4 } from 'uuid';
-import React from 'react';
 import type { ObjectFieldTemplateProps } from '@rjsf/core';
-import { getWidgetName, getSectionName } from ':/utils';
+import React from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { VernaContextProps } from ':/providers/VernaProvider';
 import { sectionDefinition, stringDefinition } from ':/templates';
 import ShowCaseWidgetProps from ':/types/Widgets';
+import { getWidgetName, getSectionName } from ':/utils';
 
 function addWidgetToUiSchemaWithSelector(
   verna: VernaContextProps,

--- a/lib/src/utils/schema/adders.ts
+++ b/lib/src/utils/schema/adders.ts
@@ -1,10 +1,10 @@
 import { v4 as uuidv4 } from 'uuid';
 import React from 'react';
 import type { ObjectFieldTemplateProps } from '@rjsf/core';
-import { getWidgetName, getSectionName } from '../utils';
-import { VernaContextProps } from '../../providers/VernaProvider';
-import { sectionDefinition, stringDefinition } from '../../templates';
-import ShowCaseWidgetProps from '../../types/Widgets';
+import { getWidgetName, getSectionName } from ':/utils';
+import { VernaContextProps } from ':/providers/VernaProvider';
+import { sectionDefinition, stringDefinition } from ':/templates';
+import ShowCaseWidgetProps from ':/types/Widgets';
 
 function addWidgetToUiSchemaWithSelector(
   verna: VernaContextProps,

--- a/lib/src/utils/schema/cleaners.ts
+++ b/lib/src/utils/schema/cleaners.ts
@@ -1,7 +1,7 @@
-import React from 'react';
 import type { ObjectFieldTemplateProps, UiSchema } from '@rjsf/core';
-import VernaJSONSchemaType from ':/types/rjsf';
+import React from 'react';
 import Section from ':/components/Fields/Section';
+import VernaJSONSchemaType from ':/types/rjsf';
 import { Maybe } from ':/types/utils';
 
 /**

--- a/lib/src/utils/schema/cleaners.ts
+++ b/lib/src/utils/schema/cleaners.ts
@@ -1,8 +1,8 @@
 import React from 'react';
 import type { ObjectFieldTemplateProps, UiSchema } from '@rjsf/core';
-import VernaJSONSchemaType from '../../types/rjsf';
-import Section from '../../components/Fields/Section';
-import { Maybe } from '../../types/utils';
+import VernaJSONSchemaType from ':/types/rjsf';
+import Section from ':/components/Fields/Section';
+import { Maybe } from ':/types/utils';
 
 /**
  * Verify & return a UiSchema with a specified order object, so it doesn't stop the workflow of the

--- a/lib/src/utils/schema/getters.ts
+++ b/lib/src/utils/schema/getters.ts
@@ -1,5 +1,5 @@
 import type { UiSchema } from '@rjsf/core';
-import VernaJSONSchemaType from '../../types/rjsf';
+import VernaJSONSchemaType from ':/types/rjsf';
 
 /**
  * Get the JSONSchema used by the library, if there is a selector specified it will return only the

--- a/lib/src/utils/schema/removers.ts
+++ b/lib/src/utils/schema/removers.ts
@@ -1,5 +1,5 @@
-import { VernaContextProps } from '../../providers/VernaProvider';
-import { getWidgetName, getSectionName } from '../utils';
+import { VernaContextProps } from ':/providers/VernaProvider';
+import { getWidgetName, getSectionName } from ':/utils';
 
 function removeWidget(verna: VernaContextProps, id: string) {
   const currentSection = getSectionName(id);

--- a/lib/src/utils/schema/updateSectionProperties.ts
+++ b/lib/src/utils/schema/updateSectionProperties.ts
@@ -1,5 +1,5 @@
-import { VernaContextProps } from '../../providers/VernaProvider';
-import { RJSF_ID_SEPARATOR } from '../../settings';
+import { VernaContextProps } from ':/providers/VernaProvider';
+import { RJSF_ID_SEPARATOR } from ':/settings';
 
 export interface SectionParameters {
   title?: string;

--- a/lib/src/utils/schema/updateWidgetProperties.ts
+++ b/lib/src/utils/schema/updateWidgetProperties.ts
@@ -1,8 +1,8 @@
 import _ from 'lodash';
+import { updateProperty, updateRequired } from './widgetPropertyUpdaters';
 import { VernaContextProps } from ':/providers/VernaProvider';
 import { RJSF_ID_SEPARATOR } from ':/settings';
 import VernaJSONSchemaType from ':/types/rjsf';
-import { updateProperty, updateRequired } from './widgetPropertyUpdaters';
 
 type Maybe<T> = T | undefined;
 export type Properties = {

--- a/lib/src/utils/schema/updateWidgetProperties.ts
+++ b/lib/src/utils/schema/updateWidgetProperties.ts
@@ -1,8 +1,8 @@
-import { VernaContextProps } from '../../providers/VernaProvider';
-import { RJSF_ID_SEPARATOR } from '../../settings';
-import { updateProperty, updateRequired } from './widgetPropertyUpdaters';
-import VernaJSONSchemaType from '../../types/rjsf';
 import _ from 'lodash';
+import { VernaContextProps } from ':/providers/VernaProvider';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import VernaJSONSchemaType from ':/types/rjsf';
+import { updateProperty, updateRequired } from './widgetPropertyUpdaters';
 
 type Maybe<T> = T | undefined;
 export type Properties = {

--- a/lib/src/utils/schema/widgetPropertyUpdaters.ts
+++ b/lib/src/utils/schema/widgetPropertyUpdaters.ts
@@ -1,8 +1,8 @@
-import { VernaContextProps } from '../../providers/VernaProvider';
-import VernaJSONSchemaType from '../../types/rjsf';
+import { VernaContextProps } from ':/providers/VernaProvider';
+import VernaJSONSchemaType from ':/types/rjsf';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import { Maybe } from ':/types/utils';
 import type { Properties } from './updateWidgetProperties';
-import { RJSF_ID_SEPARATOR } from '../../settings';
-import { Maybe } from '../../types/utils';
 
 /**
  * Generate the translation key based on those parameters

--- a/lib/src/utils/schema/widgetPropertyUpdaters.ts
+++ b/lib/src/utils/schema/widgetPropertyUpdaters.ts
@@ -1,8 +1,8 @@
-import { VernaContextProps } from ':/providers/VernaProvider';
-import VernaJSONSchemaType from ':/types/rjsf';
-import { RJSF_ID_SEPARATOR } from ':/settings';
-import { Maybe } from ':/types/utils';
 import type { Properties } from './updateWidgetProperties';
+import { VernaContextProps } from ':/providers/VernaProvider';
+import { RJSF_ID_SEPARATOR } from ':/settings';
+import VernaJSONSchemaType from ':/types/rjsf';
+import { Maybe } from ':/types/utils';
 
 /**
  * Generate the translation key based on those parameters

--- a/lib/src/utils/suspense/resourceLoader.ts
+++ b/lib/src/utils/suspense/resourceLoader.ts
@@ -1,4 +1,4 @@
-import { Maybe } from '../../types/utils';
+import { Maybe } from ':/types/utils';
 
 export type ResourceLoader<DataType, ErrorType = Error> = {
   read: () => Promise<DataType> | DataType | ErrorType;

--- a/lib/src/utils/translation/index.spec.tsx
+++ b/lib/src/utils/translation/index.spec.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import { Suspense } from 'react';
 import { createIntl, IntlProvider, type ResolvedIntlConfig } from 'react-intl';
-import VernaProvider, { WidgetsType } from ':/providers/VernaProvider';
 import VernaForm from ':/components/VernaForm';
+import VernaProvider, { WidgetsType } from ':/providers/VernaProvider';
 import {
   checkBoxesSchemaFactory,
   checkBoxesUiSchemaFactory,

--- a/lib/src/utils/translation/index.spec.tsx
+++ b/lib/src/utils/translation/index.spec.tsx
@@ -4,8 +4,8 @@ import userEvent from '@testing-library/user-event';
 import { noop } from 'lodash';
 import { Suspense } from 'react';
 import { createIntl, IntlProvider, type ResolvedIntlConfig } from 'react-intl';
-import VernaProvider, { WidgetsType } from '../../providers/VernaProvider';
-import VernaForm from '../../components/VernaForm';
+import VernaProvider, { WidgetsType } from ':/providers/VernaProvider';
+import VernaForm from ':/components/VernaForm';
 import {
   checkBoxesSchemaFactory,
   checkBoxesUiSchemaFactory,
@@ -15,8 +15,8 @@ import {
   confSchemaFactory,
   widgetsFactory,
   translationUiFactory,
-} from '../../tests/mocks/factories';
-import VernaJSONSchemaType from '../../types/rjsf';
+} from ':/tests/mocks/factories';
+import VernaJSONSchemaType from ':/types/rjsf';
 
 describe('schema translations', () => {
   const VernaSuspenseWrapper = ({

--- a/lib/src/utils/translation/index.ts
+++ b/lib/src/utils/translation/index.ts
@@ -1,7 +1,7 @@
 import { IntlFormatters } from '@formatjs/intl/src/types';
 import _ from 'lodash';
-import VernaJSONSchemaType from '../../types/rjsf';
-import { Maybe } from '../../types/utils';
+import VernaJSONSchemaType from ':/types/rjsf';
+import { Maybe } from ':/types/utils';
 
 export const DEFAULT_PROPERTY_TRANSLATION = '';
 

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../tsconfig.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    // If you update aliases defined within "paths" property,
+    // you have also to update the "resolve.alias" property in ./vite.config.js
+    "paths": {
+      ":/*": ["./src/*"]
+    }
+  }
 }

--- a/lib/vite.config.ts
+++ b/lib/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react';
 import typescript from '@rollup/plugin-typescript';
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
+export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, './src/index.ts'),
@@ -12,7 +12,7 @@ export default defineConfig(({ mode }) => ({
       formats: ['es'],
       name: 'index',
     },
-    minify: mode !== 'development',
+    minify: true,
     rollupOptions: {
       external: ['react', 'react-dom', 'react-intl'],
       output: {
@@ -33,7 +33,7 @@ export default defineConfig(({ mode }) => ({
             resolve(__dirname, './src/tests'),
             resolve(__dirname, './src/**/*.spec.tsx?'),
           ],
-          noEmitOnError: mode !== 'development',
+          noEmitOnError: true,
           rootDir: resolve(__dirname, './src'),
           target: 'ESNext',
         }),
@@ -41,4 +41,12 @@ export default defineConfig(({ mode }) => ({
     },
   },
   plugins: [react()],
-}));
+  resolve: {
+    alias: [
+      {
+        find: /:/,
+        replacement: resolve(__dirname, './src'),
+      },
+    ],
+  },
+});

--- a/lib/vite.dev.config.ts
+++ b/lib/vite.dev.config.ts
@@ -1,0 +1,49 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import react from '@vitejs/plugin-react';
+import typescript from '@rollup/plugin-typescript';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    emptyOutDir: false,
+    lib: {
+      entry: resolve(__dirname, './src/index.ts'),
+      fileName: () => 'index.js',
+      formats: ['es'],
+      name: 'index',
+    },
+    minify: false,
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react-intl'],
+      treeshake: false,
+    },
+    sourcemap: true,
+    watch: {
+      exclude: [resolve(__dirname, './src/tests'), resolve(__dirname, './src/**/*.spec.tsx?')],
+      include: [resolve(__dirname, './src/**')],
+    },
+  },
+  plugins: [
+    react(),
+    typescript({
+      declaration: true,
+      declarationDir: resolve(__dirname, './dist'),
+      exclude: [
+        resolve(__dirname, './dist'),
+        resolve(__dirname, './node_modules/**'),
+        // Ignore all test stuff
+        resolve(__dirname, './src/tests'),
+        resolve(__dirname, './src/**/*.spec.tsx?'),
+      ],
+      noEmitOnError: false,
+      rootDir: resolve(__dirname, './src'),
+      target: 'ESNext',
+    }),
+  ],
+  resolve: {
+    alias: {
+      ':': resolve(__dirname, './src'),
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "verna",
   "version": "0.0.0",
   "description": "An extensible form builder based on React JSON Schema Form.",
-  "main": "./lib/dist/verna.umd.js",
+  "main": "./lib/dist/index.js",
   "repository": "https://github.com/openfun/verna",
   "author": {
     "name": "Open FUN (France Université Numérique)",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "useDefineForClassFields": true,
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
-    "skipLibCheck": false,
-    "esModuleInterop": false,
     "allowSyntheticDefaultImports": true,
-    "strict": true,
+    "esModuleInterop": false,
     "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "module": "ESNext",
     "moduleResolution": "Node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "strict": true,
+    "target": "ESNext",
+    "useDefineForClassFields": true,
   },
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1412,6 +1412,18 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pkgr/utils@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.3.0.tgz#3b8491f112a80839450498816767eb03b7db6139"
+  integrity sha512-7dIJ9CRVzBnqyEl7diUHPUFJf/oty2SeoVzcMocc5PeOUDK9KGzvgIBjGRRzzlRDaOjh3ADwH0WeibQvi3ls2Q==
+  dependencies:
+    cross-spawn "^7.0.3"
+    is-glob "^4.0.3"
+    open "^8.4.0"
+    picocolors "^1.0.0"
+    tiny-glob "^0.2.9"
+    tslib "^2.4.0"
+
 "@rjsf/core@4.2.2":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@rjsf/core/-/core-4.2.2.tgz#cd8ee65f0c87cba05d7dd978282141ca97df003d"
@@ -2550,6 +2562,11 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 define-properties@^1.1.3, define-properties@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.4.tgz#0b14d7bd7fbeb2f3572c3a7eda80ea5d57fb05b1"
@@ -2625,6 +2642,14 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+enhanced-resolve@^5.10.0:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
+  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -2848,6 +2873,19 @@ eslint-import-resolver-node@^0.3.6:
   dependencies:
     debug "^3.2.7"
     resolve "^1.20.0"
+
+eslint-import-resolver-typescript@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.3.0.tgz#c2b9f420563bdcb4b84d550d81e579f8dc867d5b"
+  integrity sha512-vlooCGKfDX59rH5TbtluOekinPlIS5Ab+dyQUoCCJoE1IV11R/kn6J+RoMBuBkJhzJEIKJ4myQJhw6lGIXfkRA==
+  dependencies:
+    debug "^4.3.4"
+    enhanced-resolve "^5.10.0"
+    get-tsconfig "^4.2.0"
+    globby "^13.1.2"
+    is-core-module "^2.9.0"
+    is-glob "^4.0.3"
+    synckit "^0.8.1"
 
 eslint-module-utils@^2.7.3:
   version "2.7.3"
@@ -3282,6 +3320,11 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+get-tsconfig@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.2.0.tgz#ff368dd7104dab47bf923404eb93838245c66543"
+  integrity sha512-X8u8fREiYOE6S8hLbq99PeykTDoLVnxvF4DjWKJmz9xy2nNRdUcV8ZN9tniJFeKyTU3qnC9lL8n4Chd6LmVKHg==
+
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -3336,6 +3379,11 @@ globals@^13.15.0:
   dependencies:
     type-fest "^0.20.2"
 
+globalyzer@0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.0.tgz#cb76da79555669a1519d5a8edf093afaa0bf1465"
+  integrity sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==
+
 globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -3348,12 +3396,28 @@ globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globby@^13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.1.2.tgz#29047105582427ab6eca4f905200667b056da515"
+  integrity sha512-LKSDZXToac40u8Q1PQtZihbNdTYSNMuWe+K5l+oa6KgDzSvVrHXlJy40hUP522RjAIoNLJYBJi7ow+rbFpIhHQ==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.11"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
 globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==
 
-graceful-fs@^4.2.9:
+globrex@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
+
+graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
@@ -3593,6 +3657,11 @@ is-date-object@^1.0.1:
   dependencies:
     has-tostringtag "^1.0.0"
 
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -3692,6 +3761,13 @@ is-weakref@^1.0.2:
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
     call-bind "^1.0.2"
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -4646,6 +4722,15 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+open@^8.4.0:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
+
 optionator@^0.8.1:
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
@@ -5272,6 +5357,11 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
+
 slice-ansi@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
@@ -5581,6 +5671,14 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+synckit@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.1.tgz#697111240114a15a393fcb92786a4218bfead47f"
+  integrity sha512-rJEeygO5PNmcZICmrgnbOd2usi5zWE1ESc0Gn5tTmJlongoU8zCTwMFQtar2UgMSiR68vK9afPQ+uVs2lURSIA==
+  dependencies:
+    "@pkgr/utils" "^2.3.0"
+    tslib "^2.4.0"
+
 table@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.8.0.tgz#87e28f14fa4321c3377ba286f07b79b281a3b3ca"
@@ -5591,6 +5689,11 @@ table@^6.8.0:
     slice-ansi "^4.0.0"
     string-width "^4.2.3"
     strip-ansi "^6.0.1"
+
+tapable@^2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
+  integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -5613,6 +5716,14 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+tiny-glob@^0.2.9:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.9.tgz#2212d441ac17928033b110f8b3640683129d31e2"
+  integrity sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==
+  dependencies:
+    globalyzer "0.1.0"
+    globrex "^0.1.2"
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -5667,7 +5778,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.4.0, tslib@^2.1.0:
+tslib@2.4.0, tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==


### PR DESCRIPTION
## Purpose

Use relative paths to import local modules is not convenient for development.
It's not straightforward to find the location of a module and furthermore when
we move a file, it's a chore to update all related paths.
So we decided to setup alias to resolve our local modules.

```ts
// ❌ Before
import { useVerna }  from '../../providers/VernaProvider';
import { addWidget } from './schema';

// ✅ After
import { useVerna }  from ':/providers/VernaProvider';
import { addWidget } from ':/utils/schema';
```
## Proposal

- [x] Setup projects to be able to use aliased imports
- [x] Update codebase accordingly
- [ ] ~Improve build time of the lib during development~