### PR TITLE
🔧(vite) fix dynamic import warning

### DIFF
--- a/lib/src/providers/TranslationProvider/index.tsx
+++ b/lib/src/providers/TranslationProvider/index.tsx
@@ -16,7 +16,7 @@ type MessageLoaders = Record<string, MessageLoader>;
 
 const messagesLoader = (locale: string): MessageLoader =>
   resourceLoader(() =>
-    import(`:/translations/${locale}.json`).then(
+    import(`../../translations/${locale}.json`).then(
       (response: { default: ResolvedIntlConfig['messages'] }) => response.default,
     ),
   );


### PR DESCRIPTION
## Purpose

vite used @rollup/plugin-dynamic-import-vars under the hood to resolve dynamic imports. Currently, in our codebase, we use this feature to import lazily translations. But, as the doc of this plugin mentions, this kind of import must use relative path and we are currently using an alias which resolve to an absolute path. In order to remove the warning, we have to use a relative path instead of the aliased path.

## Proposal

- [x] Use a relative path to import lazily translations. 
