### PR TITLE
Ci/fix publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,8 +152,11 @@ jobs:
           name: Authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/fun/.npmrc
       - run:
-          name: Publish package
-          command: npm publish ./lib/
+          name: Copy project README into package
+          command: cp README.md ./lib/
+      - run:
+          name: Publish package as public
+          command: npm publish --access public ./lib/
   deployment:
     docker:
       - image: cimg/node:16.15

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Verna 🏗
+# Verna
 [![CircleCI](https://circleci.com/gh/openfun/verna/tree/main.svg?style=svg)](https://circleci.com/gh/openfun/verna/tree/main)
+[![npm version](https://badge.fury.io/js/@openfun%2Fverna.svg)](https://badge.fury.io/js/@openfun%2Fverna)
 
 An extensible form builder based on [React JSON Schema Form](https://github.com/rjsf-team/react-jsonschema-form).
 
@@ -20,14 +21,27 @@ You can check examples available within the `examples` folder. Take a loot at th
 
 ### Instructions
 
-🚧 **`@openfun/verna` is not yet available on NPM. Stay tuned !**
-Soon instructions to install `@openfun/verna` within your project.
+#### Install in our project
 
-To run the project, you have to run :
-1. `yarn install` 
-2. `yarn dev`
+```sh
+  yarn add -E @openfun/verna
+```
 
-You should now be able to access the playground example from http://localhost:3000
+#### Test or contribute to the project
+
+```sh
+  # -- Clone repository
+  git clone https://github.com/openfun/verna.git
+  cd verna
+  
+  # -- Install dependencies
+  yarn install
+  
+  # -- Run dev server
+  yarn dev
+```
+
+You should now be able to access the playground example from http://localhost:5173
 
 ### Project structure (Yarn workspaces)
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,6 +2,7 @@
   "name": "@openfun/verna",
   "version": "1.0.0-beta.0",
   "private": false,
+  "keywords": ["react", "form", "json-schema"],
   "description": "An extensible form builder based on React JSON Schema Form.",
   "scripts": {
     "build": "tsc && vite build && tsc-alias",


### PR DESCRIPTION
## Purpose

Currently, publish job is failing because we try to publish a scope package without explicitly define it as public. Furthermore, just before publish, we copy the project README into lib folder to embedded into published npm package.

## Proposal

- [x] Fix `publish` job
- [x] Update README